### PR TITLE
Add initial "hocker_network_create" function (and a wordpress example, including nginx frontend)

### DIFF
--- a/bin/hocker
+++ b/bin/hocker
@@ -275,4 +275,18 @@ hocker_run() {
 	echo
 }
 
+hocker_network_create() {
+	local networkName="$1"
+	shift
+
+	echo
+
+	if ! docker network inspect "$networkName" &> /dev/null; then
+		echo "Creating network '$networkName' ..."
+		docker network create "$@" "$networkName"
+	else
+		echo "Not creating network '$networkName' (already exists)"
+	fi
+}
+
 source "$script"

--- a/example/.network-create
+++ b/example/.network-create
@@ -1,0 +1,6 @@
+#!/usr/bin/env hocker
+# vim:set ft=sh:
+
+hocker_network_create "$1" \
+	--driver bridge \
+	--opt com.docker.network.bridge.name="br-$1"

--- a/example/.wordpress-nginx.conf
+++ b/example/.wordpress-nginx.conf
@@ -1,0 +1,19 @@
+server {
+	listen 80;
+	server_name wordpress-nginx;
+
+	set $proto $http_x_forwarded_proto;
+	if ($proto = "") {
+		set $proto $scheme;
+	}
+
+	location / {
+		client_max_body_size 0;
+		proxy_pass http://wordpress;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "upgrade";
+		proxy_set_header Host $host;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $proto;
+	}
+}

--- a/example/wordpress
+++ b/example/wordpress
@@ -1,0 +1,11 @@
+#!/usr/bin/env hocker
+# vim:set ft=sh:
+
+source "$scriptDir/.network-create" wordpress
+
+hocker_run 'wordpress' \
+	--network wordpress \
+	-e WORDPRESS_DB_HOST=wordpress-mysql \
+	-e WORDPRESS_DB_USER=root \
+	-e WORDPRESS_DB_PASSWORD=example \
+	-v wordpress-data:/var/www/html

--- a/example/wordpress-mysql
+++ b/example/wordpress-mysql
@@ -1,0 +1,9 @@
+#!/usr/bin/env hocker
+# vim:set ft=sh:
+
+source "$scriptDir/.network-create" wordpress
+
+hocker_run 'mysql:5.7' \
+	--network wordpress \
+	-e MYSQL_ROOT_PASSWORD=example \
+	-v wordpress-mysql:/var/lib/mysql

--- a/example/wordpress-nginx
+++ b/example/wordpress-nginx
@@ -1,0 +1,9 @@
+#!/usr/bin/env hocker
+# vim:set ft=sh:
+
+source "$scriptDir/.network-create" wordpress
+
+hocker_run 'nginx:alpine' \
+	--network wordpress \
+	-p 80:80 \
+	-v "$scriptDir/.$scriptName.conf":/etc/nginx/conf.d/default.conf:ro


### PR DESCRIPTION
```console
$ multihocker -s wordpress*

Creating network 'wordpress' ...
ozds047loni52ofw81dxfijn2

Not pulling 'wordpress' (--pull 'missing')


Starting 'wordpress' (from 'wordpress') ...
b9517d10312f850c2d7a8cec2cea8543cc88305c4abdd8165538428d9548843e


Not creating network 'wordpress' (already exists)

Not pulling 'mysql:5.7' (--pull 'missing')


Starting 'wordpress-mysql' (from 'mysql:5.7') ...
031840e782c25852ef332c7f6db7ae21c3378f9c92384836c4d865fab9f08b59


Not creating network 'wordpress' (already exists)

Not pulling 'nginx:alpine' (--pull 'missing')


Starting 'wordpress-nginx' (from 'nginx:alpine') ...
fca7f0ec85371931ef809c5099130a7f3ac1b1a9d598401c60fe9537fe2bb71a

```

Then, I hit http://localhost in my browser, waited for MySQL to initialize, and saw the WordPress setup process (as expected).

Ref #6