### PR TITLE
Add new "hocker_network_connect" function for connecting containers to networks post-creation

### DIFF
--- a/bin/hocker
+++ b/bin/hocker
@@ -289,4 +289,56 @@ hocker_network_create() {
 	fi
 }
 
+_hocker_network_has_container() {
+	local networkName="$1"
+	shift
+	local containerName="$1"
+	shift
+
+	local containerNetworks=( $(
+		docker inspect --type container --format '
+			{{- range $n, $d := .NetworkSettings.Networks -}}
+				{{- $n -}}{{- "\n" -}}
+			{{- end -}}
+		' "$containerName" 2>/dev/null
+	) )
+	if [ "${#containerNetworks[@]}" -gt 0 ]; then
+		for network in "${containerNetworks[@]}"; do
+			if [ "$network" = "$networkName" ]; then
+				return 0
+			fi
+		done
+	fi
+	return 1
+}
+
+hocker_network_connect() {
+	local opts
+	if ! opts="$(getopt -o '+' --long 'container:' -- "$@")"; then
+		panic 'hocker_network_connect getopt failed' # getopt already put an error to stderr like: getopt: unrecognized option '--wtf'
+	fi
+	eval set -- "$opts"
+
+	local containerName="$scriptName" buildDir=
+	while true; do
+		local flag="$1"
+		shift
+		case "$flag" in
+			--container) containerName="$1" && shift ;;
+			--) break ;;
+			*) panic "unknown hocker_network_connect flag '$flag'" ;;
+		esac
+	done
+
+	local networkName="$1"
+	shift
+
+	if ! _hocker_network_has_container "$networkName" "$containerName"; then
+		echo "Connecting '$containerName' to network '$networkName' ..."
+		docker network connect "$@" "$networkName" "$containerName"
+	else
+		echo "Not connecting '$containerName' to network '$networkName' (already connected)"
+	fi
+}
+
 source "$script"

--- a/example/wordpress
+++ b/example/wordpress
@@ -9,3 +9,6 @@ hocker_run 'wordpress' \
 	-e WORDPRESS_DB_USER=root \
 	-e WORDPRESS_DB_PASSWORD=example \
 	-v wordpress-data:/var/www/html
+
+source "$scriptDir/.network-create" nginx
+hocker_network_connect nginx

--- a/example/wordpress-nginx
+++ b/example/wordpress-nginx
@@ -1,9 +1,9 @@
 #!/usr/bin/env hocker
 # vim:set ft=sh:
 
-source "$scriptDir/.network-create" wordpress
+source "$scriptDir/.network-create" nginx
 
 hocker_run 'nginx:alpine' \
-	--network wordpress \
+	--network nginx \
 	-p 80:80 \
 	-v "$scriptDir/.$scriptName.conf":/etc/nginx/conf.d/default.conf:ro


### PR DESCRIPTION
Closes #6

```console
$ multihocker -s example/wordpress*

Creating network 'wordpress' ...
4301bef50ba18880133ac71c57ab71f266f315d1924f506198c2865f1495b306

Not pulling 'wordpress' (--pull 'missing')

Starting 'wordpress' (from 'wordpress') ...
74d94c6060c177259b27bc105581ac3d311db711d58fb62631a639b096d3d405

Creating network 'nginx' ...
472eabd113d7631dd374febd6d29a1a5d7696b7f61a68089f962bb3fc5bdf776
Connecting 'wordpress' to network 'nginx' ...

Not creating network 'wordpress' (already exists)

Not pulling 'mysql:5.7' (--pull 'missing')

Starting 'wordpress-mysql' (from 'mysql:5.7') ...
ab53ba5a6c0ea6037ed143fe99c8b96eaff494780caf865f4490e2c434f7fd10

Not creating network 'nginx' (already exists)

Not pulling 'nginx:alpine' (--pull 'missing')

Starting 'wordpress-nginx' (from 'nginx:alpine') ...
f8c11634d4397d7c3bd9eda5043b6a7a7a711903c915f2242121b091c6c87b6b

$ multihocker -s example/wordpress*

Not creating network 'wordpress' (already exists)

Not pulling 'wordpress' (--pull 'missing')

Not restarting 'wordpress' (--redeploy 'smart')

Not creating network 'nginx' (already exists)
Not connecting 'wordpress' to network 'nginx' (already connected)

Not creating network 'wordpress' (already exists)

Not pulling 'mysql:5.7' (--pull 'missing')

Not restarting 'wordpress-mysql' (--redeploy 'smart')

Not creating network 'nginx' (already exists)

Not pulling 'nginx:alpine' (--pull 'missing')

Not restarting 'wordpress-nginx' (--redeploy 'smart')

```