### PR TITLE
Add `--pull never` to all `docker run` invocations

### DIFF
--- a/bin/hocker
+++ b/bin/hocker
@@ -183,6 +183,7 @@ hocker_run() {
 
 	local dockerArgs=(
 		--name "$containerName"
+		--pull never
 	)
 	if [ -z "${flagValues[interactive]}" ]; then
 		dockerArgs+=(


### PR DESCRIPTION
Because `hocker_run` itself explicitly manages invocations of `docker pull`, we should tell `docker run` not to ever pull so that our hocker pull policy applies correctly.

(I noticed this with a misbehaving volume driver and `docker run` misinterpreted that error from the daemon as "image not found" and ended up trying to pull.)