### PR TITLE
Allow building a `Dockerfile` (instead of a directory) and using `docker buildx build` explicitly

### DIFF
--- a/bin/hocker
+++ b/bin/hocker
@@ -159,7 +159,7 @@ hocker_run() {
 	fi
 	eval set -- "$opts"
 
-	local containerName="$scriptName" buildDir= buildArgs=() platform=
+	local containerName="$scriptName" buildDir= buildDockerfile= buildArgs=() platform=
 	while true; do
 		local flag="$1"
 		shift
@@ -175,7 +175,11 @@ hocker_run() {
 	done
 
 	if [ -n "$buildDir" ]; then
-		[ -d "$buildDir" ] || script_error "--build specified but '$buildDir' is not a directory"
+		if [ -s "$buildDir" ] || [[ "$buildDir" == /dev/fd/* ]]; then
+			buildDockerfile="$(< "$buildDir")"
+		elif [ ! -d "$buildDir" ]; then
+			script_error "--build specified but '$buildDir' is not a directory"
+		fi
 	fi
 	if [ "${#buildArgs[@]}" -gt 0 ] && [ -z "$buildDir" ]; then
 		script_error "--build-arg specified but '--build' was not"
@@ -249,16 +253,37 @@ hocker_run() {
 			*) script_error "unrecognized value for --build '$build'" ;;
 		esac
 		buildFroms="$(
-			awk '
-				toupper($1) == "FROM" { print $2 }
+			if [ -n "$buildDockerfile" ]; then
+				exec <<<"$buildDockerfile"
+			else
+				exec < "$buildDir/Dockerfile"
+			fi
+			gawk '
+				function printfrom(from, as) {
+					if (asmap[from]) {
+						from = asmap[from]
+					}
+					if (as) {
+						asmap[as] = from
+					}
+					print from
+				}
+				toupper($1) == "FROM" {
+					if (toupper($3) == "AS") {
+						printfrom($2, $4)
+					} else {
+						printfrom($2)
+					}
+				}
 				toupper($1) == "COPY" {
 					for (i = 2; i < NF; i++) {
 						if ($i !~ /^--/) { break }
-						if ($i ~ /^--from=/) { gsub(/^--from=/, "", $i); print $i }
+						if ($i ~ /^--from=/) { gsub(/^--from=/, "", $i); printfrom($i) } # TODO also handle --from=0 etc
 					}
 				}
-			' "$buildDir/Dockerfile"
+			'
 		)"
+		buildFroms="$(sort <<<"$buildFroms" -u)"
 		# reset "alwaysPull" and "missingImages" since if we're supposed to build $imageName, we shouldn't ever pull $imageName
 		alwaysPull=(); missingImages=()
 		for buildFrom in $buildFroms; do
@@ -284,6 +309,9 @@ hocker_run() {
 
 	if [ "${#doPull[@]}" -gt 0 ]; then
 		for imageToPull in "${doPull[@]}"; do
+			if [ "$imageToPull" = 'scratch' ]; then
+				continue
+			fi
 			echo "Pulling '$imageToPull' ..."
 			local pullArgs=( "$imageToPull" )
 			if [ -n "$platform" ]; then
@@ -301,8 +329,11 @@ hocker_run() {
 		if [ -n "$platform" ]; then
 			buildArgs+=( --platform "$platform" )
 		fi
-		buildArgs+=( "$buildDir" )
-		docker build "${buildArgs[@]}"
+		if [ -n "$buildDockerfile" ]; then
+			docker build "${buildArgs[@]}" - <<<"$buildDockerfile"
+		else
+			docker build "${buildArgs[@]}" "$buildDir"
+		fi
 	elif [ -n "$buildDir" ]; then
 		echo
 		echo "Not building '$imageName' (--build '$build')"

--- a/bin/hocker
+++ b/bin/hocker
@@ -154,19 +154,20 @@ fi
 
 hocker_run() {
 	local opts
-	if ! opts="$(getopt -o '+' --long 'name:,build:,build-arg:,platform:' -- "$@")"; then
+	if ! opts="$(getopt -o '+' --long 'name:,build:,buildx:,build-arg:,platform:' -- "$@")"; then
 		panic 'hocker_run getopt failed' # getopt already put an error to stderr like: getopt: unrecognized option '--wtf'
 	fi
 	eval set -- "$opts"
 
-	local containerName="$scriptName" buildDir= buildDockerfile= buildArgs=() platform=
+	local containerName="$scriptName" buildDir= buildDockerfile= buildArgs=() buildx= platform=
 	while true; do
 		local flag="$1"
 		shift
 		case "$flag" in
 			# --redeploy-hook ? (for HUP nginx, etc)
 			--name) containerName="$1" && shift ;;
-			--build) buildDir="$1" && shift ;;
+			--build) buildDir="$1" && buildx= && shift ;;
+			--buildx) buildDir="$1" && buildx=1 && shift ;;
 			--build-arg) buildArgs+=( "$1" ) && shift ;;
 			--platform) platform="$1" && shift ;;
 			--) break ;;
@@ -330,10 +331,11 @@ hocker_run() {
 			buildArgs+=( --platform "$platform" )
 		fi
 		if [ -n "$buildDockerfile" ]; then
-			docker build "${buildArgs[@]}" - <<<"$buildDockerfile"
+			buildArgs+=( - )
 		else
-			docker build "${buildArgs[@]}" "$buildDir"
+			buildArgs+=( "$buildDir" )
 		fi
+		DOCKER_BUILDKIT="${buildx:-0}" docker ${buildx:+buildx} build "${buildArgs[@]}" <<<"$buildDockerfile"
 	elif [ -n "$buildDir" ]; then
 		echo
 		echo "Not building '$imageName' (--build '$build')"


### PR DESCRIPTION
> Add support for `--build=Dockerfile`
>
> The `--build` flag currently supports a directory to build - this adds support for specifying a file instead (thus with no directory context).
>
> This *also* suppots Bash's "process substitution" such that something like the following is doable (to inline a `Dockerfile` to build):
>
>     hocker_run --build <(printf 'FROM ...\nRUN ...\n') ...

> Allow `--buildx` as an alternate to `--build`
>
> This will build with `docker buildx build` explicitly.
